### PR TITLE
gix bug: cbor-get switch fall through

### DIFF
--- a/src/cn-get.c
+++ b/src/cn-get.c
@@ -16,6 +16,7 @@ cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
       if (cp->v.uint == (unsigned long)key) {
         return cp->next;
       }
+      break;
     case CN_CBOR_INT:
       if (cp->v.sint == (long)key) {
         return cp->next;


### PR DESCRIPTION
This PR fixes a small bug in `cn_cbor_mapget_int` that it may return a wrong data because of a switch case statement falls through.