### PR TITLE
Changes the cn_cbor_context macros to use const

### DIFF
--- a/include/cn-cbor/cn-cbor.h
+++ b/include/cn-cbor/cn-cbor.h
@@ -250,10 +250,10 @@ typedef struct cn_cbor_context {
 
 /** When USE_CBOR_CONTEXT is defined, many functions take an extra `context`
  * parameter */
-#define CBOR_CONTEXT , cn_cbor_context* context
+#define CBOR_CONTEXT , const cn_cbor_context* context
 /** When USE_CBOR_CONTEXT is defined, some functions take an extra `context`
  * parameter at the beginning */
-#define CBOR_CONTEXT_COMMA cn_cbor_context *context,
+#define CBOR_CONTEXT_COMMA const cn_cbor_context *context,
 
 #else
 


### PR DESCRIPTION
Migrated version of https://github.com/cabo/cn-cbor/pull/50

The cn_cbor_context struct itself is not modified by the cn-cbor calls that use the context struct for allocations. The struct pointer can thus be passed as `const` to these functions. This has the advantage that the context struct containing the function pointers and context pointer can reside in the ROM on an embedded system.