### PR TITLE
Drop CN_CBOR_ALIGN_READS and fix compilation with -Wcast-align

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ option(CN_CBOR_COVERALLS_SEND "Send data to coveralls site" OFF)
 option(CN_CBOR_BUILD_DOCS "Create docs using Doxygen" OFF)
 option(CN_CBOR_BUILD_TESTS "Create tests" ON)
 option(CN_CBOR_NO_FLOATS "Build without floating point support" OFF)
-option(CN_CBOR_ALIGN_READS "Use memcpy in ntoh*p()" OFF)
 option(CN_CBOR_RUN_CLANG_TIDY "Use Clang-Tidy for static analysis" OFF)
 
 if(NOT CMAKE_C_STANDARD)
@@ -98,9 +97,6 @@ endif()
 set(cbor_srcs src/cn-cbor.c src/cn-create.c src/cn-encoder.c src/cn-error.c
               src/cn-get.c src/cn-print.c)
 
-if(CN_CBOR_ALIGN_READS)
-  add_definitions(-DCBOR_ALIGN_READS)
-endif()
 if(CN_CBOR_USE_CONTEXT)
   add_definitions(-DUSE_CBOR_CONTEXT)
 endif()

--- a/src/cn-cbor.c
+++ b/src/cn-cbor.c
@@ -90,10 +90,6 @@ static double decode_half(int half)
 
 #define ntoh8p(p) (*(unsigned char *)(p))
 
-#ifndef CBOR_ALIGN_READS
-#define ntoh16p(p) (ntohs(*(unsigned short *)(p)))
-#define ntoh32p(p) (ntohl(*(unsigned long *)(p)))
-#else
 static uint16_t ntoh16p(unsigned char *p)
 {
 	uint16_t tmp;
@@ -107,7 +103,6 @@ static uint32_t ntoh32p(unsigned char *p)
 	memcpy(&tmp, p, sizeof(tmp));
 	return ntohl(tmp);
 }
-#endif /* CBOR_ALIGN_READS */
 
 static uint64_t ntoh64p(unsigned char *p)
 {


### PR DESCRIPTION
Reasoning: CN_CBOR_ALIGN_READS is by default off, which would cause
unaligned memory accesses that will result in crashes, silent memory
corruptions, or significant performance degradation (depending on
the target platform) [1]. Just changing the default to true is IMO not
really a solution, as a switch that allows generation broken binaries
has hardly legitimate use cases.

[1]: https://www.kernel.org/doc/html/latest/core-api/unaligned-memory-access.html#why-unaligned-access-is-bad